### PR TITLE
:sparkles: Add chats

### DIFF
--- a/api.go
+++ b/api.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	log.Print("Starting the server on :8080")
 	http.HandleFunc("/generate", middlewares.Auth(completion.Generate))
+	http.HandleFunc("/chats", middlewares.Auth(completion.CreateChat))
 	http.HandleFunc("/memory", middlewares.Auth(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			memory.Create(w, r)

--- a/api.go
+++ b/api.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 
+	httprouter "github.com/julienschmidt/httprouter"
+
 	completion "github.com/polyfact/api/completion"
 	memory "github.com/polyfact/api/memory"
 	middlewares "github.com/polyfact/api/middlewares"
@@ -12,19 +14,15 @@ import (
 
 func main() {
 	log.Print("Starting the server on :8080")
-	http.HandleFunc("/generate", middlewares.Auth(completion.Generate))
-	http.HandleFunc("/chats", middlewares.Auth(completion.CreateChat))
-	http.HandleFunc("/memory", middlewares.Auth(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			memory.Create(w, r)
-		} else if r.Method == http.MethodPut {
-			memory.Add(w, r)
-		} else {
-			http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
-		}
-	}))
-	http.HandleFunc("/memories", middlewares.Auth(memory.Get))
-	http.HandleFunc("/transcribe", middlewares.Auth(transcription.Transcribe))
 
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	router := httprouter.New()
+
+	router.POST("/generate", middlewares.Auth(completion.Generate))
+	router.POST("/chats", middlewares.Auth(completion.CreateChat))
+	router.POST("/transcribe", middlewares.Auth(transcription.Transcribe))
+	router.POST("/memory", middlewares.Auth(memory.Create))
+	router.PUT("/memory", middlewares.Auth(memory.Add))
+	router.GET("/memories", middlewares.Auth(memory.Get))
+
+	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/api.go
+++ b/api.go
@@ -19,6 +19,7 @@ func main() {
 
 	router.POST("/generate", middlewares.Auth(completion.Generate))
 	router.POST("/chats", middlewares.Auth(completion.CreateChat))
+	router.GET("/chat/:id/history", middlewares.Auth(completion.GetChatHistory))
 	router.POST("/transcribe", middlewares.Auth(transcription.Transcribe))
 	router.POST("/memory", middlewares.Auth(memory.Create))
 	router.PUT("/memory", middlewares.Auth(memory.Add))

--- a/completion/chat.go
+++ b/completion/chat.go
@@ -40,3 +40,16 @@ func CreateChat(w http.ResponseWriter, r *http.Request, _ router.Params) {
 
 	json.NewEncoder(w).Encode(chat)
 }
+
+func GetChatHistory(w http.ResponseWriter, r *http.Request, ps router.Params) {
+	id := ps.ByName("id")
+	user_id := r.Context().Value("user_id").(string)
+
+	messages, err := db.GetChatMessages(user_id, id)
+	if err != nil {
+		http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(messages)
+}

--- a/completion/chat.go
+++ b/completion/chat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	router "github.com/julienschmidt/httprouter"
 	db "github.com/polyfact/api/db"
 )
 
@@ -23,7 +24,7 @@ func FormatPrompt(systemPrompt string, chatHistory []db.ChatMessage, userPrompt 
 	return res
 }
 
-func CreateChat(w http.ResponseWriter, r *http.Request) {
+func CreateChat(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	user_id := r.Context().Value("user_id").(string)
 
 	if r.Method != "POST" {

--- a/completion/chat.go
+++ b/completion/chat.go
@@ -1,0 +1,41 @@
+package completion
+
+import (
+	"encoding/json"
+	"net/http"
+
+	db "github.com/polyfact/api/db"
+)
+
+func FormatPrompt(systemPrompt string, chatHistory []db.ChatMessage, userPrompt string) string {
+	res := systemPrompt
+
+	for i := len(chatHistory) - 1; i >= 0; i-- {
+		if chatHistory[i].IsUserMessage {
+			res += "\nHuman: " + chatHistory[i].Content
+		} else {
+			res += "\nAI: " + chatHistory[i].Content
+		}
+	}
+
+	res += "\nHuman: " + userPrompt + "\nAI: "
+
+	return res
+}
+
+func CreateChat(w http.ResponseWriter, r *http.Request) {
+	user_id := r.Context().Value("user_id").(string)
+
+	if r.Method != "POST" {
+		http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	chat, err := db.CreateChat(user_id)
+	if err != nil {
+		http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(chat)
+}

--- a/completion/generate.go
+++ b/completion/generate.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	router "github.com/julienschmidt/httprouter"
 	db "github.com/polyfact/api/db"
 	llm "github.com/polyfact/api/llm"
 	memory "github.com/polyfact/api/memory"
-	helpers "github.com/polyfact/api/utils"
 	utils "github.com/polyfact/api/utils"
-	"github.com/tmc/langchaingo/llms"
+	llms "github.com/tmc/langchaingo/llms"
 )
 
 type GenerateRequestBody struct {
@@ -20,7 +20,7 @@ type GenerateRequestBody struct {
 	Provider string  `json:"provider,omitempty"`
 }
 
-func Generate(w http.ResponseWriter, r *http.Request) {
+func Generate(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	user_id := r.Context().Value("user_id").(string)
 
 	if r.Method != "POST" {
@@ -50,7 +50,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		context_completion, err = helpers.FillContext(results)
+		context_completion, err = utils.FillContext(results)
 
 		if err != nil {
 			http.Error(w, "500 Internal server error", http.StatusInternalServerError)

--- a/completion/generate.go
+++ b/completion/generate.go
@@ -9,11 +9,14 @@ import (
 	llm "github.com/polyfact/api/llm"
 	memory "github.com/polyfact/api/memory"
 	helpers "github.com/polyfact/api/utils"
+	utils "github.com/polyfact/api/utils"
+	"github.com/tmc/langchaingo/llms"
 )
 
 type GenerateRequestBody struct {
 	Task     string  `json:"task"`
 	MemoryId *string `json:"memory_id,omitempty"`
+	ChatId   *string `json:"chat_id,omitempty"`
 	Provider string  `json:"provider,omitempty"`
 }
 
@@ -40,7 +43,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 
 	context_completion := ""
 
-	if input.MemoryId != nil {
+	if input.MemoryId != nil && len(*input.MemoryId) > 0 {
 		results, err := memory.Embedder(user_id, *input.MemoryId, input.Task)
 		if err != nil {
 			http.Error(w, "500 Internal server error", http.StatusInternalServerError)
@@ -77,9 +80,50 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var result llm.Result
-	var prompt string = context_completion + input.Task
+	if input.ChatId != nil && len(*input.ChatId) > 0 {
+		chat, err := db.GetChatById(*input.ChatId)
+		if err != nil {
+			http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+			return
+		}
 
-	result, err = provider.Generate(prompt, &callback)
+		if chat == nil || chat.UserID != user_id {
+			http.Error(w, "404 Not found", http.StatusNotFound)
+			return
+		}
+
+		allHistory, err := db.GetChatMessages(user_id, *input.ChatId)
+		if err != nil {
+			http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		chatHistory := utils.CutChatHistory(allHistory, 1000)
+
+		prompt := FormatPrompt(context_completion, chatHistory, input.Task)
+
+		fmt.Println(chat.ID)
+		err = db.AddChatMessage(chat.ID, true, input.Task)
+		if err != nil {
+			http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+			fmt.Println(err)
+			return
+		}
+
+		result, err = provider.Generate(prompt, &callback, &llms.CallOptions{StopWords: []string{"AI:", "Human:"}})
+
+		if err != nil {
+			http.Error(w, "500 Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		err = db.AddChatMessage(chat.ID, false, result.Result)
+
+	} else {
+		prompt := context_completion + input.Task
+
+		result, err = provider.Generate(prompt, &callback, nil)
+	}
 
 	w.Header()["Content-Type"] = []string{"application/json"}
 

--- a/db/chats.go
+++ b/db/chats.go
@@ -70,6 +70,7 @@ type ChatMessage struct {
 	ChatID        string  `json:"chat_id"`
 	IsUserMessage bool    `json:"is_user_message"`
 	Content       string  `json:"content"`
+	CreatedAt     string  `json:"created_at",omitempty`
 }
 
 type ChatMessageInsert struct {

--- a/db/chats.go
+++ b/db/chats.go
@@ -1,0 +1,54 @@
+package db
+
+type Chat struct {
+	ID            string        `json:"id"`
+	UserID        string        `json:"user_id"`
+	chat_messages []ChatMessage `json:"chat_messages"`
+}
+
+func GetChatIds(userId string) ([]Chat, error) {
+	client, err := CreateClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []Chat
+
+	_, err = client.From("chats").Select("id", "exact", false).Eq("user_id", userId).ExecuteTo(&results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+type ChatMessage struct {
+	ID            string `json:"id"`
+	ChatID        string `json:"chat_id"`
+	IsUserMessage bool   `json:"is_user_message"`
+	Content       string `json:"content"`
+}
+
+func GetChatMessages(userId string, chatId string) (Chat, error) {
+	client, err := CreateClient()
+	if err != nil {
+		panic(err)
+	}
+
+	var results Chat
+
+	str, _, err := client.From("chats").
+		Select("*, chat_messages(*)", "exact", false).
+		Single().
+		Eq("id", chatId).
+		Eq("user_id", userId).
+		ExecuteString()
+
+	panic(str)
+	// if err != nil {
+	// 	panic(err)
+	// 	// return , err
+	// }
+
+	return results, nil
+}

--- a/db/db.go
+++ b/db/db.go
@@ -1,26 +1,16 @@
 package db
 
 import (
-	"encoding/json"
-	"log"
 	"os"
 
-	supa "github.com/nedpals/supabase-go"
-	rpc "github.com/supabase/postgrest-go"
+	postgrest "github.com/supabase/postgrest-go"
 )
 
-type Kind string
-
-const (
-	Completion Kind = "completion"
-	Embed      Kind = "embedding"
-)
-
-func CreateRpcClient() (*rpc.Client, error) {
+func CreateClient() (*postgrest.Client, error) {
 	supabaseUrl := os.Getenv("SUPABASE_URL")
 	supabaseKey := os.Getenv("SUPABASE_KEY")
 
-	client := rpc.NewClient(supabaseUrl+"/rest/v1", "", nil)
+	client := postgrest.NewClient(supabaseUrl+"/rest/v1", "", nil)
 
 	if client.ClientError != nil {
 		return nil, client.ClientError
@@ -29,143 +19,4 @@ func CreateRpcClient() (*rpc.Client, error) {
 	client.TokenAuth(supabaseKey)
 
 	return client, nil
-}
-
-func CreateClient() *supa.Client {
-	supabaseUrl := os.Getenv("SUPABASE_URL")
-	supabaseKey := os.Getenv("SUPABASE_KEY")
-
-	client := supa.CreateClient(supabaseUrl, supabaseKey)
-
-	return client
-}
-
-type RequestLog struct {
-	UserID           string `json:"user_id"`
-	ModelName        string `json:"model_name"`
-	InputTokenCount  *int   `json:"input_token_count"`
-	OutputTokenCount *int   `json:"output_token_count"`
-	Kind             Kind   `json:"kind"`
-}
-
-type Memory struct {
-	ID      string `json:"id"`
-	USER_ID string `json:"user_id"`
-}
-type MatchParams struct {
-	QueryEmbedding []float64 `json:"query_embedding"`
-	MatchTreshold  float64   `json:"match_threshold"`
-	MatchCount     int16     `json:"match_count"`
-	MemoryID       string    `json:"memory_id"`
-}
-
-type MatchResult struct {
-	ID         string  `json:"id"`
-	Content    string  `json:"content"`
-	Similarity float64 `json:"similarity"`
-}
-
-type Embedding struct {
-	MEMORY_ID string    `json:"memory_id"`
-	USER_ID   string    `json:"user_id"`
-	CONTENT   string    `json:"content"`
-	EMBEDDING []float64 `json:"embedding"`
-}
-
-func toRef[T interface{}](n T) *T {
-	return &n
-}
-
-func LogRequests(
-	user_id string,
-	model_name string,
-	input_token_count int,
-	output_token_count int,
-	kind Kind,
-) {
-	supabase := CreateClient()
-
-	if kind == "" {
-		kind = "completion"
-	}
-
-	row := RequestLog{
-		UserID:           user_id,
-		ModelName:        model_name,
-		Kind:             kind,
-		InputTokenCount:  toRef(input_token_count),
-		OutputTokenCount: toRef(output_token_count),
-	}
-
-	var results []RequestLog
-	err := supabase.DB.From("request_logs").Insert(row).Execute(&results)
-
-	if err != nil {
-		panic(err)
-	}
-}
-
-func CreateMemory(memoryId string, userId string) error {
-	client := CreateClient()
-
-	err := client.DB.From("memories").Insert(Memory{ID: memoryId, USER_ID: userId}).Execute(nil)
-
-	return err
-}
-
-func AddMemory(userId string, memoryId string, content string, embedding []float64) error {
-	client := CreateClient()
-
-	err := client.DB.From("embeddings").Insert(Embedding{
-		USER_ID:   userId,
-		MEMORY_ID: memoryId,
-		CONTENT:   content,
-		EMBEDDING: embedding,
-	}).Execute(nil)
-
-	return err
-}
-
-type MemoryRecord struct {
-	ID string `json:"id"`
-}
-
-func GetMemoryIds(userId string) ([]MemoryRecord, error) {
-	client := CreateClient()
-
-	var results []MemoryRecord
-
-	err := client.DB.From("memories").Select("id").Eq("user_id", userId).Execute(&results)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return results, nil
-}
-
-func MatchEmbeddings(memoryId string, embedding []float64) ([]MatchResult, error) {
-	params := MatchParams{
-		QueryEmbedding: embedding,
-		MatchTreshold:  0.70,
-		MatchCount:     10,
-		MemoryID:       memoryId,
-	}
-
-	client, err := CreateRpcClient()
-
-	response := client.Rpc("match_embeddings", "", params)
-
-	var results []MatchResult
-	err = json.Unmarshal([]byte(response), &results)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if client.ClientError != nil {
-		return nil, err
-	}
-
-	return results, nil
 }

--- a/db/memories.go
+++ b/db/memories.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"encoding/json"
-	"log"
 )
 
 type Memory struct {
@@ -92,7 +91,7 @@ func MatchEmbeddings(memoryId string, embedding []float64) ([]MatchResult, error
 	err = json.Unmarshal([]byte(response), &results)
 
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	if client.ClientError != nil {

--- a/db/memories.go
+++ b/db/memories.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"encoding/json"
+	"log"
+)
+
+type Memory struct {
+	ID      string `json:"id"`
+	USER_ID string `json:"user_id"`
+}
+type MatchParams struct {
+	QueryEmbedding []float64 `json:"query_embedding"`
+	MatchTreshold  float64   `json:"match_threshold"`
+	MatchCount     int16     `json:"match_count"`
+	MemoryID       string    `json:"memory_id"`
+}
+
+type MatchResult struct {
+	ID         string  `json:"id"`
+	Content    string  `json:"content"`
+	Similarity float64 `json:"similarity"`
+}
+
+type Embedding struct {
+	MEMORY_ID string    `json:"memory_id"`
+	USER_ID   string    `json:"user_id"`
+	CONTENT   string    `json:"content"`
+	EMBEDDING []float64 `json:"embedding"`
+}
+
+func CreateMemory(memoryId string, userId string) error {
+	client, err := CreateClient()
+	if err != nil {
+		return err
+	}
+
+	_, _, err = client.From("memories").Insert(Memory{ID: memoryId, USER_ID: userId}, false, "", "", "exact").Execute()
+
+	return err
+}
+
+func AddMemory(userId string, memoryId string, content string, embedding []float64) error {
+	client, err := CreateClient()
+	if err != nil {
+		return err
+	}
+
+	_, _, err = client.From("embeddings").Insert(Embedding{
+		USER_ID:   userId,
+		MEMORY_ID: memoryId,
+		CONTENT:   content,
+		EMBEDDING: embedding,
+	}, false, "", "", "exact").Execute()
+
+	return err
+}
+
+type MemoryRecord struct {
+	ID string `json:"id"`
+}
+
+func GetMemoryIds(userId string) ([]MemoryRecord, error) {
+	client, err := CreateClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []MemoryRecord
+
+	_, err = client.From("memories").Select("id", "exact", false).Eq("user_id", userId).ExecuteTo(&results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func MatchEmbeddings(memoryId string, embedding []float64) ([]MatchResult, error) {
+	params := MatchParams{
+		QueryEmbedding: embedding,
+		MatchTreshold:  0.70,
+		MatchCount:     10,
+		MemoryID:       memoryId,
+	}
+
+	client, err := CreateClient()
+
+	response := client.Rpc("match_embeddings", "", params)
+
+	var results []MatchResult
+	err = json.Unmarshal([]byte(response), &results)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if client.ClientError != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/db/request_logs.go
+++ b/db/request_logs.go
@@ -1,0 +1,50 @@
+package db
+
+type Kind string
+
+const (
+	Completion Kind = "completion"
+	Embed      Kind = "embedding"
+)
+
+type RequestLog struct {
+	UserID           string `json:"user_id"`
+	ModelName        string `json:"model_name"`
+	InputTokenCount  *int   `json:"input_token_count"`
+	OutputTokenCount *int   `json:"output_token_count"`
+	Kind             Kind   `json:"kind"`
+}
+
+func toRef[T interface{}](n T) *T {
+	return &n
+}
+
+func LogRequests(
+	user_id string,
+	model_name string,
+	input_token_count int,
+	output_token_count int,
+	kind Kind,
+) {
+	supabase, err := CreateClient()
+	if err != nil {
+		panic(err)
+	}
+
+	if kind == "" {
+		kind = "completion"
+	}
+
+	row := RequestLog{
+		UserID:           user_id,
+		ModelName:        model_name,
+		Kind:             kind,
+		InputTokenCount:  toRef(input_token_count),
+		OutputTokenCount: toRef(output_token_count),
+	}
+
+	_, _, err = supabase.From("request_logs").Insert(row, false, "", "", "exact").Execute()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.0
-	github.com/nedpals/supabase-go v0.3.0
 	github.com/rakyll/openai-go v1.0.9
 	github.com/supabase/postgrest-go v0.0.7
 	github.com/tmc/langchaingo v0.0.0-20230723211647-311c3ee65e1e
@@ -42,7 +41,6 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nedpals/postgrest-go v0.1.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/googleapis/gax-go/v2 v2.8.0/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/jarcoal/httpmock v1.1.0/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -7,11 +7,13 @@ import (
 	"os"
 
 	jwt "github.com/golang-jwt/jwt/v5"
+	router "github.com/julienschmidt/httprouter"
 )
 
-func Auth(handler func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-
+func Auth(
+	handler func(http.ResponseWriter, *http.Request, router.Params),
+) func(http.ResponseWriter, *http.Request, router.Params) {
+	return func(w http.ResponseWriter, r *http.Request, httprouter router.Params) {
 		if len(r.Header["X-Access-Token"]) == 0 {
 			http.Error(w, "403 forbidden", http.StatusForbidden)
 			return
@@ -41,6 +43,6 @@ func Auth(handler func(http.ResponseWriter, *http.Request)) func(http.ResponseWr
 
 		ctx := context.WithValue(r.Context(), "user_id", userId)
 
-		handler(w, r.WithContext(ctx))
+		handler(w, r.WithContext(ctx), httprouter)
 	}
 }

--- a/transcription/transcribe.go
+++ b/transcription/transcribe.go
@@ -9,10 +9,11 @@ import (
 	"mime/multipart"
 	"net/http"
 
+	router "github.com/julienschmidt/httprouter"
 	stt "github.com/polyfact/api/stt"
 )
 
-func Transcribe(w http.ResponseWriter, r *http.Request) {
+func Transcribe(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	_, p, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	boundary := p["boundary"]
 	reader := multipart.NewReader(r.Body, boundary)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,5 +27,24 @@ func FillContext(embeddings []db.MatchResult) (string, error) {
 	}
 
 	return context, nil
+}
 
+const PROMPT_IDENTIFIER_TOKEN_COUNT int = 5
+
+func CutChatHistory(chat_messages []db.ChatMessage, max_token int) []db.ChatMessage {
+	var res []db.ChatMessage
+	tokens := 0
+
+	for _, item := range chat_messages {
+		textTokens := llm.CountTokens(item.Content, os.Getenv("OPENAI_MODEL"))
+
+		if tokens+textTokens > max_token {
+			break
+		}
+
+		res = append(res, item)
+		tokens += textTokens
+	}
+
+	return res
 }


### PR DESCRIPTION
This PR adds the possibility to:
- Create a chat by sending a POST request to `/chats`
- Making generation requests by sending the chat_id in the `/generate` request body
-  Getting the chat history with GET `/chat/:id/history`