### PR TITLE
:recycle: split completion in multiple parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 app.yaml
 vectorizer.json
+tmp/

--- a/auth/external_firebase.go
+++ b/auth/external_firebase.go
@@ -19,7 +19,10 @@ func getUserFromFirebaseToken(firebase_token string, project_id string) (string,
 	}
 
 	var objmap map[string]string
-	json.Unmarshal(public_keys, &objmap)
+	err = json.Unmarshal(public_keys, &objmap)
+	if err != nil {
+		return "", "", err
+	}
 
 	token, err := jwt.Parse(firebase_token, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {

--- a/auth/get_auth_id.go
+++ b/auth/get_auth_id.go
@@ -5,16 +5,18 @@ import (
 
 	router "github.com/julienschmidt/httprouter"
 	db "github.com/polyfact/api/db"
+	"github.com/polyfact/api/utils"
 )
 
 func GetAuthId(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 
 	projectUser, _ := db.GetProjectUserByID(user_id)
 
 	if projectUser == nil {
-		w.Write([]byte(user_id))
+		_, _ = w.Write([]byte(user_id))
+		return
 	}
 
-	w.Write([]byte(projectUser.AuthID))
+	_, _ = w.Write([]byte(projectUser.AuthID))
 }

--- a/auth/rate_limit.go
+++ b/auth/rate_limit.go
@@ -15,8 +15,8 @@ type UserRateLimitResponse struct {
 }
 
 func UserRateLimit(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
 	tokenUsage, err := db.GetUserIdMonthlyTokenUsage(user_id)
 	if err != nil {
@@ -38,5 +38,5 @@ func UserRateLimit(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }

--- a/auth/utils.go
+++ b/auth/utils.go
@@ -74,7 +74,7 @@ func TokenExchangeHandler(
 	getUserFromToken func(token string, project_id string) (string, string, error),
 ) func(w http.ResponseWriter, r *http.Request, ps router.Params) {
 	return func(w http.ResponseWriter, r *http.Request, ps router.Params) {
-		record := r.Context().Value("recordEvent").(utils.RecordFunc)
+		record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 		project_id := ps.ByName("id")
 
 		if len(r.Header["Authorization"]) == 0 {
@@ -110,7 +110,7 @@ func TokenExchangeHandler(
 				utils.RespondError(w, record, "project_retrieval_error")
 				return
 			}
-			if project.FreeUserInit == false {
+			if !project.FreeUserInit {
 				utils.RespondError(w, record, "free_user_init_disabled")
 				return
 			}
@@ -137,6 +137,6 @@ func TokenExchangeHandler(
 			return
 		}
 
-		w.Write([]byte(user_token))
+		_, _ = w.Write([]byte(user_token))
 	}
 }

--- a/completion/chat.go
+++ b/completion/chat.go
@@ -27,8 +27,8 @@ func FormatPrompt(systemPrompt string, chatHistory []db.ChatMessage, userPrompt 
 }
 
 func CreateChat(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
 	var requestBody struct {
 		SystemPrompt   *string `json:"system_prompt"`
@@ -56,13 +56,13 @@ func CreateChat(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	response, _ := json.Marshal(&chat)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(chat)
+	_ = json.NewEncoder(w).Encode(chat)
 }
 
 func GetChatHistory(w http.ResponseWriter, r *http.Request, ps router.Params) {
 	id := ps.ByName("id")
-	user_id := r.Context().Value("user_id").(string)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
 	messages, err := db.GetChatMessages(user_id, id)
 	if err != nil {
@@ -73,5 +73,5 @@ func GetChatHistory(w http.ResponseWriter, r *http.Request, ps router.Params) {
 	response, _ := json.Marshal(&messages)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(messages)
+	_ = json.NewEncoder(w).Encode(messages)
 }

--- a/completion/errors.go
+++ b/completion/errors.go
@@ -1,0 +1,15 @@
+package completion
+
+import (
+	"errors"
+)
+
+var (
+	UnknownUserId           error = errors.New("400 Unknown user Id")
+	InternalServerError     error = errors.New("500 InternalServerError")
+	UnknownModelProvider    error = errors.New("400 Unknown model provider")
+	NotFound                error = errors.New("404 Not Found")
+	RateLimitReached        error = errors.New("429 Monthly Rate Limit Reached")
+	ProjectRateLimitReached error = errors.New("429 Monthly Project Rate Limit Reached")
+	ProjectNotPremiumModel  error = errors.New("403 Project Can't Use Premium Models")
+)

--- a/completion/generate.go
+++ b/completion/generate.go
@@ -1,20 +1,13 @@
 package completion
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"sync"
-	"text/template"
-	"time"
 
 	router "github.com/julienschmidt/httprouter"
 	db "github.com/polyfact/api/db"
 	llm "github.com/polyfact/api/llm"
 	providers "github.com/polyfact/api/llm/providers"
-	memory "github.com/polyfact/api/memory"
 	utils "github.com/polyfact/api/utils"
 	webrequest "github.com/polyfact/api/web_request"
 )
@@ -28,22 +21,11 @@ type GenerateRequestBody struct {
 	Stop           *[]string   `json:"stop,omitempty"`
 	Temperature    *float32    `json:"temperature,omitempty"`
 	Stream         bool        `json:"stream,omitempty"`
-	Infos          bool        `json:"infos,omitempty"`
 	SystemPromptId *string     `json:"system_prompt_id,omitempty"`
 	SystemPrompt   *string     `json:"system_prompt,omitempty"`
 	WebRequest     bool        `json:"web,omitempty"`
 	Language       *string     `json:"language,omitempty"`
 }
-
-var (
-	UnknownUserId           error = errors.New("400 Unknown user Id")
-	InternalServerError     error = errors.New("500 InternalServerError")
-	UnknownModelProvider    error = errors.New("400 Unknown model provider")
-	NotFound                error = errors.New("404 Not Found")
-	RateLimitReached        error = errors.New("429 Monthly Rate Limit Reached")
-	ProjectRateLimitReached error = errors.New("429 Monthly Project Rate Limit Reached")
-	ProjectNotPremiumModel  error = errors.New("403 Project Can't Use Premium Models")
-)
 
 func getLanguageCompletion(language *string) string {
 	if language != nil && *language != "" {
@@ -52,112 +34,26 @@ func getLanguageCompletion(language *string) string {
 	return ""
 }
 
-type MemoryProcessResult struct {
-	Ressources        []db.MatchResult
-	ContextCompletion string
-}
-
-func getMemory(user_id string, memoryId []string, task string, infos bool) (*MemoryProcessResult, error) {
-	if memoryId == nil {
-		return nil, nil
-	}
-
-	results, err := memory.Embedder(user_id, memoryId, task)
-	if err != nil {
-		return nil, InternalServerError
-	}
-
-	context_completion, err := utils.FillContext(results)
-	if err != nil {
-		return nil, InternalServerError
-	}
-
-	response := &MemoryProcessResult{
-		ContextCompletion: context_completion,
-	}
-
-	if infos {
-		response.Ressources = results
-	}
-
-	return response, nil
-}
-
-func checkRateLimit(user_id string) error {
-	var wg sync.WaitGroup
-	var userReached bool
-	var projectReached bool
-
-	var userRateLimitErr error
-	var projectRateLimitErr error
-
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		userReached, userRateLimitErr = db.UserReachedRateLimit(user_id)
-	}()
-
-	go func() {
-		defer wg.Done()
-		projectReached, projectRateLimitErr = db.ProjectReachedRateLimit(user_id)
-	}()
-
-	wg.Wait()
-
-	if userRateLimitErr != nil {
-		return UnknownUserId
-	}
-	if projectRateLimitErr != nil {
-		return UnknownUserId
-	}
-
-	if userReached {
-		return RateLimitReached
-	}
-	if projectReached {
-		return ProjectRateLimitReached
-	}
-
-	return nil
-}
-
 func GenerationStart(user_id string, input GenerateRequestBody) (*chan providers.Result, error) {
-	result := make(chan providers.Result)
 	context_completion := ""
+	resources := []db.MatchResult{}
 
-	ressources := []db.MatchResult{}
-
-	err := checkRateLimit(user_id)
+	err := CheckRateLimit(user_id)
 	if err != nil {
 		return nil, err
 	}
 
-	language_completion := getLanguageCompletion(input.Language)
-
-	var memoryIdArray []string
-
-	if str, ok := input.MemoryId.(string); ok {
-		memoryIdArray = append(memoryIdArray, str)
-	} else if array, ok := input.MemoryId.([]interface{}); ok {
-		for _, item := range array {
-			if str, ok := item.(string); ok {
-				memoryIdArray = append(memoryIdArray, str)
-			}
-		}
-	}
-
-	memoryResult, err := getMemory(user_id, memoryIdArray, input.Task, input.Infos)
+	memoryResult, err := getMemory(user_id, input.MemoryId, input.Task)
 	if err != nil {
 		return nil, err
 	}
 
 	if memoryResult != nil {
-		ressources = memoryResult.Ressources
 		context_completion = memoryResult.ContextCompletion
+		resources = memoryResult.Resources
 	}
 
-	callback := func(provider_name string, model_name string, input_count int, output_count int) {
+	callback := func(provider_name string, model_name string, input_count int, output_count int, _completion string) {
 		db.LogRequests(user_id, provider_name, model_name, input_count, output_count, "completion")
 	}
 
@@ -166,134 +62,51 @@ func GenerationStart(user_id string, input GenerateRequestBody) (*chan providers
 		return nil, UnknownModelProvider
 	}
 
-	// if !provider.UserAllowed(user_id) {
-	// 	return nil, ProjectNotPremiumModel
-	// }
-
 	if err != nil {
 		return nil, InternalServerError
 	}
-	var system_prompt string = ""
 
-	if input.SystemPromptId != nil && len(*input.SystemPromptId) > 0 {
-		p, err := db.GetPromptById(*input.SystemPromptId)
-		if err != nil || p == nil {
-			return nil, NotFound
-		}
-
-		_, err = db.UpdatePromptUse(*input.SystemPromptId, db.PromptUse{Use: p.Use + 1})
-		if err != nil {
-			return nil, NotFound
-		}
-		system_prompt = p.Prompt
+	system_prompt, err := getSystemPrompt(input.SystemPromptId, input.SystemPrompt)
+	if err != nil {
+		return nil, err
 	}
 
+	opts := providers.ProviderOptions{}
+	if input.Stop != nil {
+		opts.StopWords = input.Stop
+	}
+	if input.Temperature != nil {
+		opts.Temperature = input.Temperature
+	}
+
+	var prompt string
 	if input.ChatId != nil && len(*input.ChatId) > 0 {
-		chat, err := db.GetChatById(*input.ChatId)
+		prompt, err = chatContext(user_id, input.Task, *input.ChatId, &system_prompt, &callback, &opts)
 		if err != nil {
-			return nil, InternalServerError
+			return nil, err
 		}
-
-		if chat == nil || chat.UserID != user_id {
-			return nil, NotFound
-		}
-
-		allHistory, err := db.GetChatMessages(user_id, *input.ChatId)
-		if err != nil {
-			return nil, InternalServerError
-		}
-
-		chatHistory := utils.CutChatHistory(allHistory, 1000)
-
-		if input.SystemPromptId == nil && chat.SystemPrompt != nil {
-			system_prompt = *(chat.SystemPrompt)
-		}
-
-		prompt := FormatPrompt(language_completion+"\n"+context_completion+"\n"+system_prompt, chatHistory, input.Task)
-
-		err = db.AddChatMessage(chat.ID, true, input.Task)
-		if err != nil {
-			return nil, InternalServerError
-		}
-
-		pre_result := provider.Generate(prompt, &callback, &providers.ProviderOptions{StopWords: &[]string{"AI:", "Human:"}})
-
-		go func() {
-			defer close(result)
-			total_result := ""
-			for v := range pre_result {
-				if memoryIdArray != nil && input.Infos && len(ressources) > 0 {
-					v.Ressources = ressources
-				}
-
-				total_result += v.Result
-				result <- v
-			}
-			go func() { _ = db.AddChatMessage(chat.ID, false, total_result) }()
-		}()
-
 	} else if input.WebRequest && input.Provider != "llama" {
-
-		res, err := webrequest.WebRequest(input.Task, input.Model)
+		prompt, err = webContext(input.Task, input.Model)
 		if err != nil {
 			return nil, err
 		}
-
-		tmpl := `
-		Date: {{.Date}}
-		Lang: {{.Language}}
-		From this request: {{.Task}}
-		and using this website content: {{.Content}}
-		answer at the above request and don't include appendix information other than the initial request.
-		Don't be creative, just be factual.
-		Always answer with the same language as the request.
-		If you don't know the answer, just say so.
-		If website content is not enough, you can use your own knowledge.
-		Use All websites content to make your relevant answer.
-		`
-
-		data := struct {
-			Task     string
-			Content  string
-			Date     string
-			Language string
-		}{
-			Task:     input.Task,
-			Content:  res,
-			Date:     time.Now().Format("2006-01-02"),
-			Language: language_completion,
-		}
-
-		var tpl bytes.Buffer
-		t := template.Must(template.New("prompt").Parse(tmpl))
-
-		if err := t.Execute(&tpl, data); err != nil {
-			fmt.Println("Error executing template:", err)
-			return nil, err
-		}
-
-		prompt := tpl.String()
-		result = provider.Generate(prompt, &callback, &providers.ProviderOptions{StopWords: input.Stop})
-
 	} else {
-
-		// Warning: Check if there is a better way to do this to avoid useless parameter:
-		if input.SystemPromptId == nil && input.SystemPrompt != nil {
-			system_prompt = *(input.SystemPrompt)
-		}
-
-		prompt := context_completion + "\n" + system_prompt + "\n" + input.Task + "\n" + language_completion
-
-		opts := &providers.ProviderOptions{}
-		if input.Stop != nil {
-			opts.StopWords = input.Stop
-		}
-		if input.Temperature != nil {
-			opts.Temperature = input.Temperature
-		}
-		result = provider.Generate(prompt, &callback, opts)
+		prompt = input.Task
 	}
 
+	prompt = context_completion + "\n" + system_prompt + "\n" + getLanguageCompletion(input.Language) + "\n" + prompt
+
+	res_chan := provider.Generate(prompt, &callback, &opts)
+
+	result := make(chan providers.Result)
+
+	go func() {
+		defer close(result)
+		for res := range res_chan {
+			result <- res
+		}
+		result <- providers.Result{Resources: resources}
+	}()
 	return &result, nil
 }
 
@@ -355,8 +168,8 @@ func Generate(w http.ResponseWriter, r *http.Request, _ router.Params) {
 		result.TokenUsage.Input = v.TokenUsage.Input
 		result.TokenUsage.Output += v.TokenUsage.Output
 
-		if len(v.Ressources) > 0 {
-			result.Ressources = v.Ressources
+		if len(v.Resources) > 0 {
+			result.Resources = v.Resources
 		}
 	}
 

--- a/completion/generate.go
+++ b/completion/generate.go
@@ -129,7 +129,6 @@ func GenerationStart(user_id string, input GenerateRequestBody) (*chan providers
 	ressources := []db.MatchResult{}
 
 	err := checkRateLimit(user_id)
-
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +226,7 @@ func GenerationStart(user_id string, input GenerateRequestBody) (*chan providers
 				total_result += v.Result
 				result <- v
 			}
-			err = db.AddChatMessage(chat.ID, false, total_result)
+			go db.AddChatMessage(chat.ID, false, total_result)
 		}()
 
 	} else if input.WebRequest && input.Provider != "llama" {

--- a/completion/memory_context.go
+++ b/completion/memory_context.go
@@ -1,0 +1,51 @@
+package completion
+
+import (
+	"github.com/polyfact/api/db"
+	"github.com/polyfact/api/memory"
+	"github.com/polyfact/api/utils"
+)
+
+func parseMemoryIdArray(memoryId interface{}) []string {
+	var memoryIdArray []string
+
+	if str, ok := memoryId.(string); ok {
+		memoryIdArray = append(memoryIdArray, str)
+	} else if array, ok := memoryId.([]interface{}); ok {
+		for _, item := range array {
+			if str, ok := item.(string); ok {
+				memoryIdArray = append(memoryIdArray, str)
+			}
+		}
+	}
+	return memoryIdArray
+}
+
+type MemoryProcessResult struct {
+	Resources         []db.MatchResult
+	ContextCompletion string
+}
+
+func getMemory(user_id string, memoryId interface{}, task string) (*MemoryProcessResult, error) {
+	memoryIdArray := parseMemoryIdArray(memoryId)
+	if memoryIdArray == nil {
+		return nil, nil
+	}
+
+	results, err := memory.Embedder(user_id, memoryIdArray, task)
+	if err != nil {
+		return nil, InternalServerError
+	}
+
+	context_completion, err := utils.FillContext(results)
+	if err != nil {
+		return nil, InternalServerError
+	}
+
+	response := &MemoryProcessResult{
+		ContextCompletion: context_completion,
+		Resources:         results,
+	}
+
+	return response, nil
+}

--- a/completion/rate_limit.go
+++ b/completion/rate_limit.go
@@ -1,0 +1,46 @@
+package completion
+
+import (
+	"sync"
+
+	"github.com/polyfact/api/db"
+)
+
+func CheckRateLimit(user_id string) error {
+	var wg sync.WaitGroup
+	var userReached bool
+	var projectReached bool
+
+	var userRateLimitErr error
+	var projectRateLimitErr error
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		userReached, userRateLimitErr = db.UserReachedRateLimit(user_id)
+	}()
+
+	go func() {
+		defer wg.Done()
+		projectReached, projectRateLimitErr = db.ProjectReachedRateLimit(user_id)
+	}()
+
+	wg.Wait()
+
+	if userRateLimitErr != nil {
+		return UnknownUserId
+	}
+	if projectRateLimitErr != nil {
+		return UnknownUserId
+	}
+
+	if userReached {
+		return RateLimitReached
+	}
+	if projectReached {
+		return ProjectRateLimitReached
+	}
+
+	return nil
+}

--- a/completion/stream.go
+++ b/completion/stream.go
@@ -30,8 +30,8 @@ var upgrader = websocket.Upgrader{
 }
 
 func Stream(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	user_id := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		utils.RespondError(w, record, "communication_error")
@@ -50,7 +50,7 @@ func Stream(w http.ResponseWriter, r *http.Request, _ router.Params) {
 		return
 	}
 
-	recordEventRequest := r.Context().Value("recordEventRequest").(utils.RecordRequestFunc)
+	recordEventRequest := r.Context().Value(utils.ContextKeyRecordEventRequest).(utils.RecordRequestFunc)
 
 	record = func(response string, props ...utils.KeyValue) {
 		recordEventRequest(string(p), response, user_id, props...)
@@ -141,6 +141,10 @@ generation_loop:
 
 	if input.MemoryId != nil && input.Infos {
 		infosJSON, err := json.Marshal(result)
+		if err != nil {
+			utils.RespondErrorStream(conn, record, "invalid_json")
+			return
+		}
 
 		infos := "[INFOS]:" + string(infosJSON)
 		byteMessage := []byte(infos)

--- a/completion/stream.go
+++ b/completion/stream.go
@@ -120,8 +120,8 @@ generation_loop:
 		result.TokenUsage.Input += v.TokenUsage.Input
 		result.TokenUsage.Output += v.TokenUsage.Output
 
-		if len(v.Ressources) > 0 {
-			result.Ressources = v.Ressources
+		if len(v.Resources) > 0 {
+			result.Resources = v.Resources
 		}
 		select {
 		case <-chan_stop:
@@ -139,7 +139,7 @@ generation_loop:
 		}
 	}
 
-	if input.MemoryId != nil && input.Infos {
+	if input.MemoryId != nil {
 		infosJSON, err := json.Marshal(result)
 		if err != nil {
 			utils.RespondErrorStream(conn, record, "invalid_json")

--- a/completion/system_prompt_context.go
+++ b/completion/system_prompt_context.go
@@ -1,0 +1,28 @@
+package completion
+
+import (
+	"github.com/polyfact/api/db"
+)
+
+func getSystemPrompt(system_prompt_id *string, system_prompt *string) (string, error) {
+	var result string = ""
+
+	if system_prompt != nil && len(*system_prompt) > 0 {
+		result = *system_prompt
+	}
+
+	if system_prompt_id != nil && len(*system_prompt_id) > 0 {
+		p, err := db.GetPromptById(*system_prompt_id)
+		if err != nil || p == nil {
+			return "", NotFound
+		}
+
+		_, err = db.UpdatePromptUse(*system_prompt_id, db.PromptUse{Use: p.Use + 1})
+		if err != nil {
+			return "", NotFound
+		}
+		result = p.Prompt
+	}
+
+	return result, nil
+}

--- a/completion/web_context.go
+++ b/completion/web_context.go
@@ -1,0 +1,49 @@
+package completion
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/polyfact/api/web_request"
+)
+
+func webContext(task string, model *string) (string, error) {
+	res, err := webrequest.WebRequest(task, model)
+	if err != nil {
+		return "", err
+	}
+
+	tmpl := `
+		Date: {{.Date}}
+		From this request: {{.Task}}
+		and using this website content: {{.Content}}
+		answer at the above request and don't include appendix information other than the initial request.
+		Don't be creative, just be factual.
+		Always answer with the same language as the request.
+		If you don't know the answer, just say so.
+		If website content is not enough, you can use your own knowledge.
+		Use All websites content to make your relevant answer.
+		`
+
+	data := struct {
+		Task    string
+		Content string
+		Date    string
+	}{
+		Task:    task,
+		Content: res,
+		Date:    time.Now().Format("2006-01-02"),
+	}
+
+	var tpl bytes.Buffer
+	t := template.Must(template.New("prompt").Parse(tmpl))
+
+	if err := t.Execute(&tpl, data); err != nil {
+		fmt.Println("Error executing template:", err)
+		return "", err
+	}
+
+	return tpl.String(), nil
+}

--- a/db/chats.go
+++ b/db/chats.go
@@ -72,11 +72,11 @@ func CreateChat(userId string, systemPrompt *string, SystemPromptId *string) (*C
 }
 
 type ChatMessage struct {
-	ID            *string `json:"id",omitempty`
+	ID            *string `json:"id"`
 	ChatID        string  `json:"chat_id"`
 	IsUserMessage bool    `json:"is_user_message"`
 	Content       string  `json:"content"`
-	CreatedAt     string  `json:"created_at",omitempty`
+	CreatedAt     string  `json:"created_at"`
 }
 
 type ChatMessageInsert struct {

--- a/db/memories.go
+++ b/db/memories.go
@@ -36,7 +36,9 @@ func CreateMemory(memoryId string, userId string, public bool) error {
 		return err
 	}
 
-	_, _, err = client.From("memories").Insert(Memory{ID: memoryId, UserId: userId, Public: public}, false, "", "", "exact").Execute()
+	_, _, err = client.From("memories").
+		Insert(Memory{ID: memoryId, UserId: userId, Public: public}, false, "", "", "exact").
+		Execute()
 
 	return err
 }
@@ -87,6 +89,9 @@ func MatchEmbeddings(memoryIds []string, userId string, embedding []float64) ([]
 	}
 
 	client, err := CreateClient()
+	if err != nil {
+		return nil, err
+	}
 
 	response := client.Rpc("retrieve_embeddings", "", params)
 

--- a/image_generation/image_generation.go
+++ b/image_generation/image_generation.go
@@ -37,14 +37,13 @@ func storeImageBucket(reader io.Reader, path string) (string, error) {
 }
 
 func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 	request, _ := json.Marshal(r.URL.Query())
 	prompt := r.URL.Query().Get("p")
 	provider := r.URL.Query().Get("provider")
-	recordEventRequest := r.Context().Value("recordEventRequest").(utils.RecordRequestFunc)
+	recordEventRequest := r.Context().Value(utils.ContextKeyRecordEventRequest).(utils.RecordRequestFunc)
 
-	var record utils.RecordFunc
-	record = func(response string, props ...utils.KeyValue) {
+	var record utils.RecordFunc = func(response string, props ...utils.KeyValue) {
 		recordEventRequest(string(request), response, user_id, props...)
 	}
 
@@ -86,9 +85,9 @@ func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
 		response, _ := json.Marshal(&image)
 		record(string(response))
 
-		json.NewEncoder(w).Encode(image)
+		_ = json.NewEncoder(w).Encode(image)
 	} else {
 		record("[Raw image]")
-		io.Copy(w, reader)
+		_, _ = io.Copy(w, reader)
 	}
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -10,8 +10,8 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
 	id := r.URL.Query().Get("key")
 
@@ -29,12 +29,12 @@ func Get(w http.ResponseWriter, r *http.Request, _ router.Params) {
 
 	record(store.Value)
 
-	w.Write([]byte(store.Value))
+	_, _ = w.Write([]byte(store.Value))
 }
 
 func Set(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	user_id := r.Context().Value("user_id").(string)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
 	var data struct {
 		Key   string `json:"key"`

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -11,7 +11,7 @@ import (
 var ErrUnknownModel = errors.New("Unknown model")
 
 type Provider interface {
-	Generate(prompt string, c *func(string, string, int, int), opts *providers.ProviderOptions) chan providers.Result
+	Generate(prompt string, c providers.ProviderCallback, opts *providers.ProviderOptions) chan providers.Result
 	UserAllowed(user_id string) bool
 }
 

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -42,7 +42,6 @@ func defaultModel(model string) (string, string) {
 }
 
 func NewProvider(provider string, model *string) (Provider, error) {
-	fmt.Println("%v, %v", provider, model)
 	if provider == "" && model == nil {
 		provider = "openai"
 	}

--- a/llm/providers/langchaingo.go
+++ b/llm/providers/langchaingo.go
@@ -52,7 +52,7 @@ func (m LangchainProvider) Call(prompt string, opts *ProviderOptions) (string, e
 
 func (m LangchainProvider) Generate(
 	task string,
-	c *func(string, string, int, int),
+	c ProviderCallback,
 	opts *ProviderOptions,
 ) chan Result {
 	chan_res := make(chan Result)
@@ -71,7 +71,7 @@ func (m LangchainProvider) Generate(
 			}
 
 			if c != nil {
-				(*c)("cohere", m.ModelName, m.Model.GetNumTokens(input_prompt), m.Model.GetNumTokens(completion))
+				(*c)("cohere", m.ModelName, m.Model.GetNumTokens(input_prompt), m.Model.GetNumTokens(completion), completion)
 			}
 
 			tokenUsage.Input += m.Model.GetNumTokens(input_prompt)

--- a/llm/providers/langchaingo.go
+++ b/llm/providers/langchaingo.go
@@ -89,7 +89,6 @@ func (m LangchainProvider) Generate(
 				"Generation failed after 5 retries",
 			),
 		}
-		return
 	}(chan_res)
 
 	return chan_res

--- a/llm/providers/openai.go
+++ b/llm/providers/openai.go
@@ -108,7 +108,6 @@ func (m OpenAIStreamProvider) Generate(task string, c *func(string, string, int,
 				"Generation failed after 5 retries",
 			),
 		}
-		return
 	}()
 
 	return chan_res

--- a/llm/providers/options.go
+++ b/llm/providers/options.go
@@ -17,6 +17,8 @@ type TokenUsage struct {
 type Result struct {
 	Result     string           `json:"result"`
 	TokenUsage TokenUsage       `json:"token_usage"`
-	Ressources []db.MatchResult `json:"ressources,omitempty"`
+	Resources  []db.MatchResult `json:"ressources,omitempty"`
 	Err        error
 }
+
+type ProviderCallback *func(string, string, int, int, string)

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -17,8 +17,8 @@ import (
 const BatchSize int = 512
 
 func Create(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	userId, ok := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	userId, ok := r.Context().Value(utils.ContextKeyUserID).(string)
 	if !ok {
 		utils.RespondError(w, record, "user_id_missing")
 		return
@@ -58,8 +58,8 @@ func Create(w http.ResponseWriter, r *http.Request, _ router.Params) {
 
 func Add(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	decoder := json.NewDecoder(r.Body)
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	userId := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	userId := r.Context().Value(utils.ContextKeyUserID).(string)
 
 	var requestBody struct {
 		ID       string `json:"id"`
@@ -113,16 +113,12 @@ func Add(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	response_str, _ := json.Marshal(&response)
 	record(string(response_str))
 
-	json.NewEncoder(w).Encode(response)
-}
-
-type memoryRecord struct {
-	ID string `json:"id"`
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func Get(w http.ResponseWriter, r *http.Request, _ router.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	userId, ok := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	userId, ok := r.Context().Value(utils.ContextKeyUserID).(string)
 	if !ok {
 		utils.RespondError(w, record, "user_id_error")
 		return
@@ -146,7 +142,7 @@ func Get(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	response_str, _ := json.Marshal(&response)
 	record(string(response_str))
 
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func Embedder(userId string, memoryId []string, task string) ([]db.MatchResult, error) {

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -32,15 +32,14 @@ func parseJWT(token string) (jwt.MapClaims, error) {
 }
 
 func createContextWithUserID(r *http.Request, userID string) context.Context {
-	recordEventWithUserID := r.Context().Value("recordEventWithUserID").(utils.RecordWithUserIDFunc)
-	newCtx := context.WithValue(r.Context(), "user_id", userID)
+	recordEventWithUserID := r.Context().Value(utils.ContextKeyRecordEventWithUserID).(utils.RecordWithUserIDFunc)
+	newCtx := context.WithValue(r.Context(), utils.ContextKeyUserID, userID)
 
-	var recordEvent utils.RecordFunc
-	recordEvent = func(response string, props ...utils.KeyValue) {
+	var recordEvent utils.RecordFunc = func(response string, props ...utils.KeyValue) {
 		recordEventWithUserID(response, userID, props...)
 	}
 
-	newCtx = context.WithValue(newCtx, "recordEvent", recordEvent)
+	newCtx = context.WithValue(newCtx, utils.ContextKeyRecordEvent, recordEvent)
 
 	return newCtx
 }
@@ -52,7 +51,7 @@ func authenticateAndHandle(
 	token string,
 	handler func(http.ResponseWriter, *http.Request, router.Params),
 ) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 	if token == "" {
 		utils.RespondError(w, record, "no_token")
 		return

--- a/middlewares/handle_panic.go
+++ b/middlewares/handle_panic.go
@@ -40,22 +40,24 @@ func getErrorMessage(rec interface{}) string {
 func AddRecord(r *http.Request) {
 	var recordEventRequest utils.RecordRequestFunc
 	recordEventRequest = func(request string, response string, userID string, props ...utils.KeyValue) {
-		pId, _ := db.GetProjectForUserId(userID)
-		projectId := "00000000-0000-0000-0000-000000000000"
+		go func() {
+			pId, _ := db.GetProjectForUserId(userID)
+			projectId := "00000000-0000-0000-0000-000000000000"
 
-		if pId != nil {
-			projectId = *pId
-		}
-		properties := make(map[string]string)
-		properties["path"] = string(r.URL.Path)
-		properties["projectId"] = projectId
-		properties["requestBody"] = request
-		properties["responseBody"] = response
-		for _, element := range props {
-			properties[element.Key] = element.Value
-		}
-		posthog.Event("API Request", userID, properties)
-		db.LogEvents(string(r.URL.Path), userID, projectId, request, response)
+			if pId != nil {
+				projectId = *pId
+			}
+			properties := make(map[string]string)
+			properties["path"] = string(r.URL.Path)
+			properties["projectId"] = projectId
+			properties["requestBody"] = request
+			properties["responseBody"] = response
+			for _, element := range props {
+				properties[element.Key] = element.Value
+			}
+			posthog.Event("API Request", userID, properties)
+			db.LogEvents(string(r.URL.Path), userID, projectId, request, response)
+		}()
 	}
 
 	buf, _ := ioutil.ReadAll(r.Body)

--- a/posthog/posthog.go
+++ b/posthog/posthog.go
@@ -16,12 +16,12 @@ func IdentifyUser(auth_id string, user_id string, email string) {
 	client := posthog.New(POSTHOG_API_KEY)
 	defer client.Close()
 
-	client.Enqueue(posthog.Identify{
+	_ = client.Enqueue(posthog.Identify{
 		DistinctId: auth_id,
 		Properties: posthog.NewProperties().Set("email", email),
 	})
 
-	client.Enqueue(posthog.Alias{
+	_ = client.Enqueue(posthog.Alias{
 		DistinctId: auth_id,
 		Alias:      user_id,
 	})
@@ -41,7 +41,7 @@ func Event(eventName string, distinctId string, props map[string]string) {
 		properties = properties.Set(key, value)
 	}
 
-	client.Enqueue(posthog.Capture{
+	_ = client.Enqueue(posthog.Capture{
 		DistinctId: distinctId,
 		Event:      eventName,
 		Properties: properties,

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetPromptById(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 	id := ps.ByName("id")
 	result, err := db.GetPromptById(id)
 	if err != nil {
@@ -22,11 +22,11 @@ func GetPromptById(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func GetPromptByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 	name := ps.ByName("name")
 	result, err := db.GetPromptByName(name)
 	if err != nil {
@@ -37,11 +37,11 @@ func GetPromptByName(w http.ResponseWriter, r *http.Request, ps httprouter.Param
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func GetAllPrompts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 	queryParams := r.URL.Query()
 
 	var filters db.SupabaseFilters
@@ -90,13 +90,13 @@ func GetAllPrompts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func CreatePrompt(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
-	user_id := r.Context().Value("user_id").(string)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 
 	var input db.PromptInsert
 
@@ -116,12 +116,12 @@ func CreatePrompt(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func UpdatePrompt(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	user_id := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 
 	id := ps.ByName("id")
 	var input db.PromptUpdate
@@ -139,12 +139,12 @@ func UpdatePrompt(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	response, _ := json.Marshal(&result)
 	record(string(response))
 
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func DeletePrompt(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	record := r.Context().Value("recordEvent").(utils.RecordFunc)
-	user_id := r.Context().Value("user_id").(string)
+	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
+	user_id := r.Context().Value(utils.ContextKeyUserID).(string)
 
 	id := ps.ByName("id")
 	if err := db.DeletePrompt(id, user_id); err != nil {

--- a/utils/error.go
+++ b/utils/error.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -342,7 +343,10 @@ func RespondError(w http.ResponseWriter, record RecordFunc, errorCode string, me
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(apiError.StatusCode)
-	json.NewEncoder(w).Encode(apiError)
+	err := json.NewEncoder(w).Encode(apiError)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func RespondErrorStream(conn *websocket.Conn, record RecordFunc, errorCode string, message ...string) {
@@ -362,5 +366,8 @@ func RespondErrorStream(conn *websocket.Conn, record RecordFunc, errorCode strin
 
 	res, _ := json.Marshal(apiError)
 
-	conn.WriteMessage(websocket.TextMessage, []byte("[ERROR]:"+string(res)))
+	err := conn.WriteMessage(websocket.TextMessage, []byte("[ERROR]:"+string(res)))
+	if err != nil {
+		fmt.Println(err)
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,3 +48,12 @@ func CutChatHistory(chat_messages []db.ChatMessage, max_token int) []db.ChatMess
 
 	return res
 }
+
+type ContextKey string
+
+const (
+	ContextKeyUserID                ContextKey = "user_id"
+	ContextKeyRecordEvent           ContextKey = "recordEvent"
+	ContextKeyRecordEventWithUserID ContextKey = "recordEventWithUserID"
+	ContextKeyRecordEventRequest    ContextKey = "recordEventRequest"
+)


### PR DESCRIPTION
The generate.go has become a bit messy.
This PR splits the GenerationStart functions into multiple smaller parts that will make the code easier to read.
It will also make it simpler to parallelize the db calls to improve the first output token performance.